### PR TITLE
[#18] Modifying ParameterHelper::get*() signatures

### DIFF
--- a/Tests/ParameterHelperTest.php
+++ b/Tests/ParameterHelperTest.php
@@ -36,11 +36,18 @@
 		public function test_getDefaultValues() {
 			$ph = new ParameterHelper();
 
-			$this->assertEquals('Chris', $ph->get('non-existent', 'Chris'));
-			$this->assertEquals(123, $ph->getInt('non-existent', 123));
-			$this->assertEquals(true, $ph->getBool('non-existent', true));
-			$this->assertEquals('Test', $ph->getString('non-existent', 'Test'));
-			$this->assertEquals(18.5, $ph->getFloat('non-existent', 18.5));
+			self::assertEquals('Chris', $ph->get('non-existent', 'Chris'));
+			self::assertEquals(123, $ph->getInt('non-existent', 123));
+			self::assertEquals(true, $ph->getBool('non-existent', true));
+			self::assertEquals('Test', $ph->getString('non-existent', 'Test'));
+			self::assertEquals(18.5, $ph->getFloat('non-existent', 18.5));
+			self::assertNull($ph->get('non-existent'));
+			self::assertNull($ph->getBool('non-existent'));
+			self::assertNull($ph->getFloat('non-existent'));
+			self::assertNull($ph->getInt('non-existent'));
+			self::assertNull($ph->getString('non-existent'));
+
+			return;
 		}
 
 		public function test_GetValues() {

--- a/Utilities/ParameterHelper.php
+++ b/Utilities/ParameterHelper.php
@@ -82,7 +82,7 @@
 		 * @param bool|null $default Optional Default value that is returned if key is not found.
 		 * @return bool Bool value of key or default value if not present.
 		 */
-		public function getBool(string $key, $default = null) : bool {
+		public function getBool(string $key, $default = null) : ?bool {
 			if (!$this->has($key)) {
 				return $default;
 			}
@@ -97,7 +97,7 @@
 		 * @param float|null $default Optional Default value that is returned if key is not found.
 		 * @return float Float value of key or default value if not present.
 		 */
-		public function getFloat(string $key, $default = null) : float {
+		public function getFloat(string $key, $default = null) : ?float {
 			if (!$this->has($key)) {
 				return $default;
 			}
@@ -112,7 +112,7 @@
 		 * @param integer|null $default Optional Default value that is returned if key is not found.
 		 * @return int Integer value of key or default value if not present.
 		 */
-		public function getInt(string $key, $default = null) : int {
+		public function getInt(string $key, $default = null) : ?int {
 			if (!$this->has($key)) {
 				return $default;
 			}
@@ -149,7 +149,7 @@
 		 * @param mixed $default Optional Default value that is returned if key is not found.
 		 * @return string String value of key or default value if not present.
 		 */
-		public function getString(string $key, $default = null) : string {
+		public function getString(string $key, $default = null) : ?string {
 			if (!$this->has($key)) {
 				return $default;
 			}


### PR DESCRIPTION
Switched returns for `getBool()`, `getFloat()`, `getInt()`, and `getString()` to allow a default `null` value.